### PR TITLE
Fix PF blocking for CDN sites with resolver-specific IPs

### DIFF
--- a/WillpowerKit/Sources/WillpowerKit/PacketFilterManager.swift
+++ b/WillpowerKit/Sources/WillpowerKit/PacketFilterManager.swift
@@ -80,6 +80,15 @@ public final class PacketFilterManager: Sendable {
         "mask.apple-dns.net"
     ]
 
+    /// IPs written to /etc/hosts when blocking — not real server addresses.
+    private static let hostsBlockPlaceholderIPs: Set<String> = [
+        "127.0.0.1", "0.0.0.0", "::1", "::"
+    ]
+
+    /// Resolvers for PF rule generation. `nil` = system default (ISP/router DNS, what
+    /// browsers use). Public resolvers are included because CDN edges vary by resolver.
+    private static let pfLookupNameservers: [String?] = [nil, "8.8.8.8", "1.1.1.1"]
+
     /// Start blocking the given domains using pf firewall
     /// - Parameter domains: Array of domain names to block
     public func startBlock(domains: [String]) throws {
@@ -238,18 +247,43 @@ public final class PacketFilterManager: Sendable {
 
     // MARK: - Private Helpers
 
-    /// Resolve a hostname to IP addresses using external DNS (bypasses hosts file)
+    /// Resolve a hostname to IP addresses from multiple DNS sources.
+    /// Unions system DNS (what browsers use) with public resolvers, since CDN edges
+    /// like Fastly return different IPs depending on the resolver.
     private func resolveHostname(_ hostname: String) -> [String] {
-        var ips: [String] = []
+        var ips = Set<String>()
 
-        // Use dig to query external DNS directly, bypassing hosts file
-        // This is critical because the hosts file may already have the domain blocked
+        for nameserver in Self.pfLookupNameservers {
+            ips.formUnion(digResolve(hostname: hostname, recordType: "A", nameserver: nameserver))
+            ips.formUnion(digResolve(hostname: hostname, recordType: "AAAA", nameserver: nameserver))
+        }
+
+        ips.subtract(Self.hostsBlockPlaceholderIPs)
+
+        let result = Array(ips)
+        if result.isEmpty {
+            logger.debug("No IPs resolved for \(hostname)")
+        } else {
+            logger.debug("Resolved \(hostname) -> \(result)")
+        }
+
+        return result
+    }
+
+    /// Query a single DNS record type via dig, optionally targeting a specific nameserver.
+    private func digResolve(hostname: String, recordType: String, nameserver: String?) -> Set<String> {
+        var ips = Set<String>()
+
         let process = Process()
         let pipe = Pipe()
 
         process.executableURL = URL(fileURLWithPath: "/usr/bin/dig")
-        // Query Google's DNS directly to bypass local hosts file
-        process.arguments = ["+short", "@8.8.8.8", hostname, "A"]
+        var arguments = ["+short"]
+        if let nameserver {
+            arguments.append("@\(nameserver)")
+        }
+        arguments.append(contentsOf: [hostname, recordType])
+        process.arguments = arguments
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
 
@@ -258,50 +292,23 @@ public final class PacketFilterManager: Sendable {
             process.waitUntilExit()
 
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                for line in output.components(separatedBy: .newlines) {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    // Only add valid IPv4 addresses (not CNAMEs or empty lines)
-                    if !trimmed.isEmpty && trimmed.range(of: "^[0-9.]+$", options: .regularExpression) != nil {
-                        ips.append(trimmed)
+            guard let output = String(data: data, encoding: .utf8) else { return ips }
+
+            for line in output.components(separatedBy: .newlines) {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { continue }
+
+                if recordType == "A" {
+                    if trimmed.range(of: "^[0-9.]+$", options: .regularExpression) != nil {
+                        ips.insert(trimmed)
                     }
+                } else if trimmed.contains(":") {
+                    ips.insert(trimmed)
                 }
             }
         } catch {
-            logger.debug("dig failed for \(hostname): \(error.localizedDescription)")
-        }
-
-        // Also resolve IPv6 addresses
-        let process6 = Process()
-        let pipe6 = Pipe()
-
-        process6.executableURL = URL(fileURLWithPath: "/usr/bin/dig")
-        process6.arguments = ["+short", "@8.8.8.8", hostname, "AAAA"]
-        process6.standardOutput = pipe6
-        process6.standardError = FileHandle.nullDevice
-
-        do {
-            try process6.run()
-            process6.waitUntilExit()
-
-            let data = pipe6.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                for line in output.components(separatedBy: .newlines) {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    // Only add valid IPv6 addresses
-                    if !trimmed.isEmpty && trimmed.contains(":") {
-                        ips.append(trimmed)
-                    }
-                }
-            }
-        } catch {
-            logger.debug("dig AAAA failed for \(hostname): \(error.localizedDescription)")
-        }
-
-        if ips.isEmpty {
-            logger.debug("No IPs resolved for \(hostname)")
-        } else {
-            logger.debug("Resolved \(hostname) -> \(ips)")
+            let via = nameserver ?? "system"
+            logger.debug("dig \(recordType) via \(via) failed for \(hostname): \(error.localizedDescription)")
         }
 
         return ips


### PR DESCRIPTION
## Summary

- Fixes blocked CDN-backed domains (e.g. reddit.com) remaining accessible when the browser's DNS resolver returns different IPs than Google DNS (`8.8.8.8`)
- Updates `PacketFilterManager.resolveHostname` to union IPs from system DNS, `8.8.8.8`, and `1.1.1.1` when building pf firewall rules
- Filters out `/etc/hosts` placeholder IPs (`127.0.0.1`, `0.0.0.0`, etc.) so Layer 2 rules target real server addresses

Fixes #15

## Problem

Willpower's Layer 2 (pf) blocking resolved domains via `dig @8.8.8.8` only. CDN sites like Reddit (Fastly) return different edge IPs depending on the DNS resolver. When a user's system DNS returned `151.101.113.140` for `www.reddit.com` but pf rules only blocked `151.101.65.140`, `151.101.1.140`, etc., Reddit remained accessible while other blocked sites continued to work.

## Test plan

Tested locally on macOS with an active blocklist that includes `reddit.com`.

**Setup:** Built the fix from Xcode and ran the debug daemon manually as root (`sudo …/WillpowerDaemon`), since Reinstall from a debug build fails silently with a codesigning error — macOS won't launch a privileged daemon signed with Apple Development.

**Before the fix (and before re-applying rules):** `www.reddit.com` resolved to `151.101.113.140`, but pf rules only covered the 8.8.8.8 IPs (`.65`, `.1`, `.129`, `.193`). Reddit loaded in the browser; `curl -4 -I https://www.reddit.com` returned `HTTP/2 200`.

**After restarting the daemon (fresh DNS resolution + rule apply):** `151.101.113.140` appeared in `/etc/pf.anchors/com.willpower`, and `curl -4 -I https://www.reddit.com` failed with "Couldn't connect to server." Reddit was blocked in the browser as expected.

**Commands used to verify:**
```bash
dig +short www.reddit.com A
sudo pfctl -a com.willpower -sr | grep 151.101   # anchor is com.willpower, not willpower
curl -4 -m 5 -I https://www.reddit.com
```

**Note:** Fastly CDN IPs can rotate after rules are written. If blocking slips again mid-session, restarting the daemon (or toggling the blocklist) forces a re-resolve. Periodic re-resolution while a block is active would be a good follow-up, but is out of scope for this PR.